### PR TITLE
Translate into German language

### DIFF
--- a/src/main/resources/assets/exp_bottling/lang/de_de.json
+++ b/src/main/resources/assets/exp_bottling/lang/de_de.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Blöcke",
+  "block.exp_bottling.exp_bottling_machine": "EP Abfüllmaschine",
+
+  "_comment": "Items",
+  "item.exp_bottling.bottled_exp": "Erfahrungsfläschchen",
+  "item.exp_bottling.bottled_exp.tooltip.0": "Erfahrung: %,d",
+
+  "_comment": "Container",
+  "container.exp_bottling.exp_bottling_machine": "EP Abfüllmaschine"
+}


### PR DESCRIPTION
This is what I can translate via the lang file, however in german using `BS` to mark the removal of one character is very unusual, using U+21E6 (⇦) or similar would make the function of the button a lot more clearer