### PR TITLE
Update de_de.json

### DIFF
--- a/src/main/resources/assets/exp_bottling/lang/de_de.json
+++ b/src/main/resources/assets/exp_bottling/lang/de_de.json
@@ -21,5 +21,5 @@
   "gui.exp_bottling.exp_bottling_machine.button.8": "8",
   "gui.exp_bottling.exp_bottling_machine.button.9": "9",
   "gui.exp_bottling.exp_bottling_machine.button.lv": "Lv",
-  "gui.exp_bottling.exp_bottling_machine.button.bs": "BS"
+  "gui.exp_bottling.exp_bottling_machine.button.bs": "←"
 }


### PR DESCRIPTION
It is uncommon to see `BS`  in the German language  being used as marking Backspace, so we used the more common `←` (U+2190).